### PR TITLE
Add Ollama Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-ollama</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-chat-memory-jdbc</artifactId>
 		</dependency>
 


### PR DESCRIPTION
Added Spring Module for ollama.
To configure ollama for the bot, simply use the following configuration:

```yaml
spring:
  ai:
    ollama:
      chat:
        model: llama3.1:8b
    model:
      chat: ollama
```